### PR TITLE
added stricter typing for country prop

### DIFF
--- a/src/countryCodes.ts
+++ b/src/countryCodes.ts
@@ -251,6 +251,6 @@ const countryCodes = [
   'GB-WLS',
   'GB-ZET',
   'US-CA',
-];
+] as const;
 
 export default countryCodes;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import countryCodes from './countryCodes';
 export type CountryCode = typeof countryCodes[number];
 
 export interface Props extends HTMLAttributes<HTMLImageElement> {
-  country?: CountryCode;
+  country?: CountryCode | Omit<string, CountryCode>;
   role?: string;
   size?: number;
   alt?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,10 @@
 import React, { FC, HTMLAttributes } from 'react';
 import countryCodes from './countryCodes';
 
+export type CountryCode = typeof countryCodes[number];
+
 export interface Props extends HTMLAttributes<HTMLImageElement> {
-  country?: string;
+  country?: CountryCode;
   role?: string;
   size?: number;
   alt?: string;


### PR DESCRIPTION
At the moment, the `country` prop is typed as `string`, while the set of legal country codes is limited.

We can leverage the `countryCodes` array to build up a `CountryCode` type that we can use to better type the `country` prop. Moreover, we can export it for external usage.

Note that the proposed solution is not breaking for existing codebases (we loosely type `country` to be of type `CountryCode | Omit<string, CountryCode>`).